### PR TITLE
Unpin requests; allow later 2.x versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
     ],
     python_requires=">=3.7",
     install_requires=[
-        "requests==2.25.1",
+        "requests>=2.25.1,<3.0",
     ],
     extras_require={
         "tox": ["tox==3.23.0"],


### PR DESCRIPTION
Closes issue #23 .

We are also facing problems with this library requesting a very specific version of `requests`. It can't be installed alongside libraries that require later versions, although, it appears to work fine with later 2.x versions.

In the absence of extensive testing, can we just not forbid later 2.x versions?